### PR TITLE
Add rebuilding on file changes when using the watch.js script.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -419,9 +419,9 @@
       }
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
     "body-parser": {
@@ -489,9 +489,9 @@
       }
     },
     "chokidar": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+      "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "1.0.0",
   "scripts": {
     "start": "node app.js",
+    "watch": "node watch.js",
     "build": "node build.js"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^12.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",
+    "chokidar": "^3.4.1",
     "rollup": "^2.3.4",
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.0.3",

--- a/watch.js
+++ b/watch.js
@@ -1,0 +1,42 @@
+const chokidar = require("chokidar");
+const { fork } = require("child_process");
+
+const restartProcess = (childProcess) => {
+  try {
+    childProcess.kill("SIGHUP");
+    const [_, command, ...args] = process.argv;
+    childProcess = fork("./app.js", args, {
+      detached: true,
+      stdio: "inherit",
+    }).unref();
+  } catch (err) {
+    console.log(err);
+  } finally {
+    process.exit();
+  }
+};
+
+const main = async () => {
+  let watcher;
+  console.log(
+    `cmd+C will not work! Use 'kill -15 ${process.pid}' to kill this process.`
+  );
+  const [_, command, ...args] = process.argv;
+  const watchedFiles = args.reduce((arr, arg, i) => {
+    if (arg === "--watch" && typeof args[i + 1] === "string") {
+      return [...arr, args[i + 1]];
+    }
+    return arr;
+  }, []);
+  watcher = chokidar.watch(["src", ...watchedFiles]);
+  const childProcess = fork("./app.js", args, {
+    detached: true,
+    stdio: "inherit",
+  });
+  await !!childProcess;
+  watcher.on("change", (path) => {
+    restartProcess(childProcess);
+  });
+};
+
+main();

--- a/watch.js
+++ b/watch.js
@@ -3,12 +3,12 @@ const { fork } = require("child_process");
 
 const restartProcess = (childProcess) => {
   try {
-    childProcess.kill("SIGHUP");
+    childProcess.kill("SIGTERM");
     const [_, command, ...args] = process.argv;
     childProcess = fork("./app.js", args, {
       detached: true,
       stdio: "inherit",
-    }).unref();
+    });
   } catch (err) {
     console.log(err);
   } finally {
@@ -18,9 +18,6 @@ const restartProcess = (childProcess) => {
 
 const main = async () => {
   let watcher;
-  console.log(
-    `cmd+C will not work! Use 'kill -15 ${process.pid}' to kill this process.`
-  );
   const [_, command, ...args] = process.argv;
   const watchedFiles = args.reduce((arr, arg, i) => {
     if (arg === "--watch" && typeof args[i + 1] === "string") {
@@ -36,6 +33,9 @@ const main = async () => {
   await !!childProcess;
   watcher.on("change", (path) => {
     restartProcess(childProcess);
+  });
+  process.on("SIGINT", function () {
+    childProcess.kill("SIGTERM");
   });
 };
 


### PR DESCRIPTION
This PR is directly inspired by the [gatsby-reload plugin](https://www.gatsbyjs.org/packages/gatsby-plugin-node-reload/) I hacked it together last night.

My first approach was to try and dive into the JungleJS code but due to the static build process, I ended up with some horrible code hacks. 

This is more of an 80% solution to the problem of live reloading as it rebuilds the static assets on file changes, I like it because it reuses the existing app.js script with minimal changes.  

To get live reloading working I was thinking of taking a similar process to [servør](https://github.com/lukejacksonn/servor) [here](https://github.com/lukejacksonn/servor/blob/master/servor.js#L48-L58) but that would require some diving into the junglejs appServer to implement.

If you think there's another solution worth implementing I'm more than happy to hear about it!